### PR TITLE
Ported to Windows

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,31 +1,56 @@
 # == Class: pentaho::config
+
+
 class pentaho::config {
 
+  # JOE
+	if $::osfamily == 'Windows' {
+	  $exec_provider = 'cygwin'
+	} else { 
+	  $exec_provider = 'posix'
+	}
+  
   if $caller_module_name != $module_name {
     fail("Use of private class ${name} by ${caller_module_name}")
   }
 
   exec { "/bin/mkdir -p ${pentaho::pentaho_solutions_path}" :
+    # TODO: I added command when I error trialed. JOE
+    command => "/bin/mkdir -p ${pentaho::pentaho_solutions_path}",
     unless => "/usr/bin/stat ${pentaho::pentaho_solutions_path}",
+    provider    => $exec_provider,
   } ->
-  exec { "/bin/cp -r ${pentaho::temp_folder}/biserver-ce/pentaho-solutions ${pentaho::pentaho_solutions_path}" :
-    unless => "/usr/bin/stat ${pentaho::pentaho_solutions_path}/pentaho-solutions",
+  # I get this errors for some reason on one Windows server:
+	# Notice: /Stage[main]/Pentaho::Config/Exec[/bin/cp -r 'c:/Temp/biserver-ce/pentaho-solutions' 'e:/Fast2/pentaho']/returns: /bin/cp: cannot stat ΓÇÿc:/Temp/biserver-ce/pentaho-solutionsΓÇÖ: No such file or directory
+	exec { "/bin/cp -r '${pentaho::temp_folder}/biserver-ce/pentaho-solutions' '${pentaho::pentaho_solutions_path}'": 
+    unless => "/usr/bin/stat '${pentaho::pentaho_solutions_path}/pentaho-solutions'",
+    provider    => $exec_provider,
   }
-
+  
+  if !$pentaho::install_samples {
+		# Remove samples.
+		file { "${pentaho::pentaho_solutions_path}/pentaho-solutions/system/default-content/samples.zip":
+			ensure => absent,
+			subscribe => Exec["/bin/cp -r '${pentaho::temp_folder}/biserver-ce/pentaho-solutions' '${pentaho::pentaho_solutions_path}'"],
+		}		
+  }
+  
   Augeas {
-    require => Exec["/bin/cp -r ${pentaho::temp_folder}/biserver-ce/pentaho-solutions ${pentaho::pentaho_solutions_path}"],
+    require => Exec["/bin/cp -r '${pentaho::temp_folder}/biserver-ce/pentaho-solutions' '${pentaho::pentaho_solutions_path}'"],
   }
   # Specify the hibernate file to use
   $hibernate_file = $pentaho::db_type ? {
     'mysql' => 'mysql5.hibernate.cfg.xml',
     'pgsql' => 'postgresql.hibernate.cfg.xml',
   }
-  augeas { 'config_file' :
-    lens    => 'Xml.lns',
-    incl    => "${pentaho::pentaho_solutions_path}/pentaho-solutions/system/hibernate/hibernate-settings.xml",
-    changes => [
-      "set settings/config-file/#text system/hibernate/${hibernate_file}",
-    ],
+  unless $::osfamily == 'Windows' {
+	  augeas { 'config_file' :
+	    lens    => 'Xml.lns',
+	    incl    => "${pentaho::pentaho_solutions_path}/pentaho-solutions/system/hibernate/hibernate-settings.xml",
+	    changes => [
+	      "set settings/config-file/#text system/hibernate/${hibernate_file}",
+	    ],
+	  }  
   }
 
   # Specify delegate class
@@ -34,16 +59,18 @@ class pentaho::config {
     'pgsql' => 'org.quartz.impl.jdbcjobstore.PostgreSQLDelegate',
   }
 
-  augeas { 'quartz_properties' :
-    lens    => 'simplevars.lns',
-    incl    => "${pentaho::pentaho_solutions_path}/pentaho-solutions/system/quartz/quartz.properties",
-    changes => [
-      "set org.quartz.jobStore.driverDelegateClass ${delegate_class}",
-    ],
+  unless $::osfamily == 'Windows' {
+	  augeas { 'quartz_properties' :
+	    lens    => 'simplevars.lns',
+	    incl    => "${pentaho::pentaho_solutions_path}/pentaho-solutions/system/quartz/quartz.properties",
+	    changes => [
+	      "set org.quartz.jobStore.driverDelegateClass ${delegate_class}",
+	    ],
+	  }
   }
-
+  
   File {
-    require => Exec["/bin/cp -r ${pentaho::temp_folder}/biserver-ce/pentaho-solutions ${pentaho::pentaho_solutions_path}"],
+    require => Exec["/bin/cp -r '${pentaho::temp_folder}/biserver-ce/pentaho-solutions' '${pentaho::pentaho_solutions_path}'"],
   }
 
   file { "${pentaho::pentaho_solutions_path}/pentaho-solutions/system/jackrabbit/repository.xml" :
@@ -59,14 +86,20 @@ class pentaho::config {
     content => template('pentaho/log4j/log4j_osgi.xml.erb'),
   }
 
-  # Fixing incorrect permissions
-  $directories = ["${pentaho::pentaho_solutions_path}/pentaho-solutions/system/osgi", "${pentaho::pentaho_solutions_path}/pentaho-solutions/system/logs", "${pentaho::pentaho_solutions_path}/pentaho-solutions/system/logs/audit", "${pentaho::pentaho_solutions_path}/pentaho-solutions/system/jackrabbit", $pentaho::log_directory]
-
-  file { $directories :
-    ensure => directory,
-    owner  => $pentaho::applicationserver_user,
-    group  => $pentaho::applicationserver_group,
-    mode   => '0755',
+  unless $::osfamily == 'Windows' {
+	  # Fixing incorrect permissions
+	  $directories = ["${pentaho::pentaho_solutions_path}/pentaho-solutions/system/osgi", "${pentaho::pentaho_solutions_path}/pentaho-solutions/system/logs", "${pentaho::pentaho_solutions_path}/pentaho-solutions/system/logs/audit", "${pentaho::pentaho_solutions_path}/pentaho-solutions/system/jackrabbit", $pentaho::log_directory]
+	
+	  # For settings advanced Windows permissions you need the acl module. http://stackoverflow.com/questions/25087069/puppet-and-windows-directory-permissions
+	  file { $directories :
+	    ensure => directory,
+	    owner  => $pentaho::applicationserver_user,
+	    group  => $pentaho::applicationserver_group,
+	    # Group need write support because else the Puppet agent wont be able to create subdirectories. JOE
+	    # mode   => '0775',
+	    mode   => '0755',
+	    
+	  }
   }
 
 }

--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -84,10 +84,21 @@ class pentaho::database (
   $db_collate             = $pentaho::params::db_collate,
 ) inherits pentaho::params {
 
+  # JOE*
+  /*
+  if $::osfamily == 'Windows' {
+    $mysql_service = Service['MySQL']
+  } else { 
+    $mysql_service = Class['mysql::server']
+  }
+  */
+  $mysql_service = Class['mysql::server']
+  
   file { "${pentaho::temp_folder}/quartz.sql" :
     ensure => file,
     source => "puppet:///modules/pentaho/${pentaho::version}/${pentaho::db_type}/create_quartz.sql",
     before => Mysql::Db['quartz'],
+    source_permissions => ignore,
   }
 
   case $pentaho::db_type {
@@ -98,7 +109,7 @@ class pentaho::database (
         charset  => $db_charset,
         collate  => $db_collate,
         sql      => "${pentaho::temp_folder}/quartz.sql",
-        require  => Class['mysql::server'],
+        require  => $mysql_service,
       } ->
       mysql::db { 'repository' :
         user     => $hibernate_db_user,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -84,6 +84,11 @@
 #    (string) The log directory
 #    Default: /var/log/pentaho
 #
+#  [*install_samples*]
+#    (boolean) If to install samples reports and mondrian datasources in /public. Controls if samples.zip is copied to default-content.
+#    Default: true
+#
+#
 # === Examples
 #
 #  include pentaho
@@ -124,9 +129,12 @@ class pentaho (
   $jackrabbit_db_password  = $pentaho::params::jackrabbit_db_password,
   $pentaho_solutions_path  = $pentaho::params::pentaho_solutions_path,
   $pentaho_source_url      = $pentaho::params::pentaho_source_url,
+  $pentaho_source_checksum = $pentaho::params::pentaho_source_checksum,
   $h2driver_source_url     = $pentaho::params::h2driver_source_url,
   $temp_folder             = $pentaho::params::temp_folder,
   $log_directory           = $pentaho::params::log_directory,
+  $manage_tomcat_web_xml   = $pentaho::params::manage_tomcat_web_xml,
+  $install_samples         = $pentaho::params::install_samples,
 ) inherits pentaho::params {
 
   include ::stdlib

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,8 +1,15 @@
 # == Class: pentaho::params
 class pentaho::params {
 
+  # JOE
+	if $::osfamily == 'Windows' { 
+	  $default_temp_folder = 'c:/Temp'
+	} else { 
+	  $default_temp_folder = '/var/tmp'
+	}
+  
   $version = '5.1'
-
+  
   # Application Server
   $applicationserver_base  = '/usr/share/tomcat'
   $applicationserver_user  = 'tomcat'
@@ -30,8 +37,14 @@ class pentaho::params {
   $country                = 'US'
   $pentaho_solutions_path = '/opt/pentaho'
   $pentaho_source_url     = 'http://downloads.sourceforge.net/project/pentaho/Business%20Intelligence%20Server/5.1/biserver-ce-5.1.0.0-752.zip?r=&ts=1410402175&use_mirror=iweb'
-  $temp_folder            = '/var/tmp'
+  $pentaho_source_checksum = false
+  $temp_folder            = $default_temp_folder
   $log_directory          = '/var/log/pentaho'
+  
+  # Tomcat
+  $manage_tomcat_web_xml  = true
+  
+  $install_samples        = true
 
   case $::osfamily {
     'RedHat' : {
@@ -39,6 +52,9 @@ class pentaho::params {
     }
     'Debian' : {
       $postgresql_jdbc_driver_package = 'libpostgresql-jdbc-java'
+    }
+    'Windows' : {
+      warning('Experimental support for Windows.')
     }
     default : { fail("The ${::osfamily} operating system is not supported with the pentaho module") }
   }

--- a/manifests/webapp.pp
+++ b/manifests/webapp.pp
@@ -1,49 +1,61 @@
 # == Class: pentaho::webapp
 class pentaho::webapp {
 
+  # JOE
+  if $::osfamily == 'Windows' {
+    $exec_provider = 'cygwin'
+  } else { 
+    $exec_provider = 'posix'
+  }
+  
   if $caller_module_name != $module_name {
     fail("Use of private class ${name} by ${caller_module_name}")
   }
 
-  exec { "/bin/cp -r ${pentaho::temp_folder}/biserver-ce/tomcat/webapps/pentaho* ${pentaho::applicationserver_base}/webapps/" :
+  exec { "/bin/cp -r ${pentaho::temp_folder}/biserver-ce/tomcat/webapps/pentaho* '${pentaho::applicationserver_base}/webapps/'" :
     unless => "/usr/bin/stat ${pentaho::applicationserver_base}/webapps/pentaho",
+    provider    => $exec_provider,
   } ->
   file { "${pentaho::applicationserver_base}/webapps/pentaho/META-INF/context.xml" :
     ensure  => file,
-    content => template("pentaho/context/${pentaho::db_type}/context.xml.erb"),
+    content => template("pentaho/context/${pentaho::db_type}/context.xml.erb"), 
   }
 
-  Augeas {
-    require => File["${pentaho::applicationserver_base}/webapps/pentaho/META-INF/context.xml"],
-  }
-  augeas { 'base_solution' :
-    lens    => 'Xml.lns',
-    incl    => "${pentaho::applicationserver_base}/webapps/pentaho/WEB-INF/web.xml",
-    changes => [
-      "set web-app/context-param[1]/param-value/#text ${pentaho::pentaho_solutions_path}/pentaho-solutions",
-    ],
-  }
-  augeas { 'listen_address' :
-    lens    => 'Xml.lns',
-    incl    => "${pentaho::applicationserver_base}/webapps/pentaho/WEB-INF/web.xml",
-    changes => [
-      "set web-app/context-param[3]/param-value/#text http://${pentaho::listen_ip}:8080/pentaho",
-    ],
-  }
-  augeas { 'rm_hsqldb_autostartup' :
-    lens    => 'Xml.lns',
-    incl    => "${pentaho::applicationserver_base}/webapps/pentaho/WEB-INF/web.xml",
-    changes => [
-      "rm /files${pentaho::applicationserver_base}/webapps/pentaho/WEB-INF/web.xml/web-app/context-param[10]",
-    ],
-  }
-  augeas { 'rm_hsqldb_listener' :
-    lens    => 'Xml.lns',
-    incl    => "${pentaho::applicationserver_base}/webapps/pentaho/WEB-INF/web.xml",
-    changes => [
-      "rm /files${pentaho::applicationserver_base}/webapps/pentaho/WEB-INF/web.xml/web-app/listener[3]",
-    ],
-  }
+  unless $::osfamily == 'Windows' {
+	  Augeas {
+	    require => File["${pentaho::applicationserver_base}/webapps/pentaho/META-INF/context.xml"],
+	  }
+	  if $pentaho::manage_tomcat_web_xml {
+		  augeas { 'base_solution' :
+		    lens    => 'Xml.lns',
+		    incl    => "${pentaho::applicationserver_base}/webapps/pentaho/WEB-INF/web.xml",
+		    changes => [
+		      "set web-app/context-param[1]/param-value/#text ${pentaho::pentaho_solutions_path}/pentaho-solutions",
+		    ],
+		  }
+		  augeas { 'listen_address' :
+		    lens    => 'Xml.lns',
+		    incl    => "${pentaho::applicationserver_base}/webapps/pentaho/WEB-INF/web.xml",
+		    changes => [
+		      "set web-app/context-param[3]/param-value/#text http://${pentaho::listen_ip}:8080/pentaho",
+		    ],
+		  }
+		  augeas { 'rm_hsqldb_autostartup' :
+		    lens    => 'Xml.lns',
+		    incl    => "${pentaho::applicationserver_base}/webapps/pentaho/WEB-INF/web.xml",
+		    changes => [
+		      "rm /files${pentaho::applicationserver_base}/webapps/pentaho/WEB-INF/web.xml/web-app/context-param[10]",
+		    ],
+		  }
+		  augeas { 'rm_hsqldb_listener' :
+		    lens    => 'Xml.lns',
+		    incl    => "${pentaho::applicationserver_base}/webapps/pentaho/WEB-INF/web.xml",
+		    changes => [
+		      "rm /files${pentaho::applicationserver_base}/webapps/pentaho/WEB-INF/web.xml/web-app/listener[3]",
+		    ],
+		  }
+	  }
+	}
 
   file { "${pentaho::applicationserver_base}/webapps/pentaho/WEB-INF/classes/log4j.xml" :
     ensure  => file,

--- a/templates/context/mysql/context.xml.erb
+++ b/templates/context/mysql/context.xml.erb
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Context path="/pentaho" docbase="webapps/pentaho/">
+<Context path="/pentaho" docBase="webapps/pentaho/">
   <Resource validationQuery="select 1" url="jdbc:mysql://<%= @db_host %>:<%= @db_port %>/hibernate" driverClassName="com.mysql.jdbc.Driver"
             password="<%= @hibernate_db_password %>" username="<%= @hibernate_db_user %>" maxWait="10000" maxIdle="5" maxActive="20"
             factory="org.apache.commons.dbcp.BasicDataSourceFactory" type="javax.sql.DataSource"

--- a/templates/context/pgsql/context.xml.erb
+++ b/templates/context/pgsql/context.xml.erb
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Context path="/pentaho" docbase="webapps/pentaho/">
+<Context path="/pentaho" docBase="webapps/pentaho/">
   <Resource validationQuery="select 1" url="jdbc:postgresql://<%= @db_host %>:<%= @db_port %>/hibernate" driverClassName="org.postgresql.Driver" password="<%= @hibernate_db_password %>"
             username="<%= @hibernate_db_user %>" maxWait="10000" maxIdle="5" maxActive="20" factory="org.apache.commons.dbcp.BasicDataSourceFactory"
             type="javax.sql.DataSource" auth="Container" name="jdbc/Hibernate"/>


### PR DESCRIPTION
This are my code changes as discussed in issue #10 for porting this module to Windows. I have used this code in production for several months on mixed Windows/Linux servers.

In order to minimize the changes required in order to make it run on Windows I've relied on Cygwin for providing the Unix commands needed for the many execs. Where packages is needed I've used Chocolatey which is a package management tool for Windows.

For this module to work on Windows you also need my code changes for the module https://github.com/JohnEricson/puppet-archive and https://github.com/JohnEricson/puppetlabs-mysql which I've also ported to Windows.
